### PR TITLE
A small performance trick

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.2.0"
 authors = ["Gulshanur Rahman<gulshanur@gmail.com>"]
 edition = "2018"
 
+[lib]
+bench = false
+
 [dev-dependencies]
 criterion = "0.3.4"
 rupantor = "0.3"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -66,7 +66,7 @@ impl Phonetic {
 
         let mut prefix = ' ';
         let mut current_input = &input[0..];
-        let mut output = String::with_capacity(input.len());
+        let mut output = String::with_capacity(input.len() * 3);
 
         while !current_input.is_empty() {
             let match_result = self


### PR DESCRIPTION
A Bengali character needs three times the space of an English character. Estimate the capacity more accurately to reduce the number of further allocations.

Benchmarks:
<pre>group                    after                                  before
-----                    -----                                  ------
okkhor ami<font color="#26A269"><b>               1.00   975.9±11.91ns        ? ?/sec</b></font>    1.05  1021.9±10.32ns        ? ?/sec
okkhor bistarito<font color="#26A269"><b>         1.00      2.7±0.03µs        ? ?/sec</b></font>    1.03      2.8±0.03µs        ? ?/sec
okkhor kormo<font color="#26A269"><b>             1.00    940.2±9.14ns        ? ?/sec</b></font>    1.03   969.8±11.26ns        ? ?/sec
okkhor long word<font color="#26A269"><b>         1.00      2.7±0.04µs        ? ?/sec</b></font>    1.01      2.7±0.05µs        ? ?/sec
okkhor new<font color="#26A269"><b>               1.00     10.0±0.11µs        ? ?/sec</b></font>    1.01     10.1±0.15µs        ? ?/sec
okkhor sentence 1<font color="#26A269"><b>        1.00      9.5±0.08µs        ? ?/sec</b></font>    1.02      9.7±0.10µs        ? ?/sec
okkhor sentence 2<font color="#26A269"><b>        1.00     32.5±0.31µs        ? ?/sec</b></font>    1.00     32.6±0.43µs        ? ?/sec
okkhor sonar bangla<font color="#26A269"><b>      1.00      7.8±0.09µs        ? ?/sec</b></font>    1.01      7.8±0.10µs        ? ?/sec
rupantor ami<font color="#26A269"><b>             1.00  1371.8±15.57ns        ? ?/sec</b></font>    1.00  1372.0±17.30ns        ? ?/sec
rupantor bistarito       1.00      6.1±0.08µs        ? ?/sec<font color="#26A269"><b>    1.00      6.1±0.09µs        ? ?/sec</b></font>
rupantor kormo<font color="#26A269"><b>           1.00      2.7±0.02µs        ? ?/sec</b></font>    1.01      2.7±0.04µs        ? ?/sec
rupantor long word       1.01      4.6±0.05µs        ? ?/sec<font color="#26A269"><b>    1.00      4.5±0.05µs        ? ?/sec</b></font>
rupantor new             1.00    470.0±3.68µs        ? ?/sec<font color="#26A269"><b>    1.00    469.8±6.54µs        ? ?/sec</b></font>
rupantor sentence 1      1.00     14.1±0.16µs        ? ?/sec<font color="#26A269"><b>    1.00     14.1±0.14µs        ? ?/sec</b></font>
rupantor sentence 2<font color="#26A269"><b>      1.00     52.6±0.60µs        ? ?/sec</b></font>    1.00     52.6±0.57µs        ? ?/sec
rupantor sonar bangla<font color="#26A269"><b>    1.00     12.9±0.16µs        ? ?/sec</b></font>    1.00     12.9±0.16µs        ? ?/sec
</pre>

I had to add `lib` section in the `Cargo.toml` to prevent running the default bencher to save the baselines and compare with [critcmp](https://lib.rs/crates/critcmp).

Thanks!